### PR TITLE
Disable "Slutför köp" when cart is empty

### DIFF
--- a/frontend/src/components/checkout.rs
+++ b/frontend/src/components/checkout.rs
@@ -371,7 +371,7 @@ impl Checkout {
                     ],
                     attrs! { At::Disabled => true },
                     "Slutför Köp",
-                ] 
+                ]
             },
             if let Some(message) = &self.confirm_button_message {
                 div![C![C.wide_button_message], message]

--- a/frontend/src/components/checkout.rs
+++ b/frontend/src/components/checkout.rs
@@ -337,11 +337,27 @@ impl Checkout {
                 ],
             ],
             if !self.disabled {
-                button![
-                    C![C.wide_button, C.border_on_focus],
-                    simple_ev(Ev::Click, CheckoutMsg::ConfirmPurchase),
-                    "Slutför Köp",
-                ]
+                if self.transaction_bundles.is_empty() {
+                    button![
+                        C![C.greyed_out, C.wide_button, C.border_on_focus],
+                        div![
+                            style! {
+                                St::Position => "absolute",
+                                St::MarginTop => "-0.25em",
+                                St::Filter => "invert(100%)",
+                            },
+                        ],
+                        attrs! { At::Disabled => true },
+                        "Slutför Köp",
+                    ] 
+                }
+                else {
+                    button![
+                        C![C.wide_button, C.border_on_focus],
+                        simple_ev(Ev::Click, CheckoutMsg::ConfirmPurchase),
+                        "Slutför Köp",
+                    ]
+                }
             } else {
                 button![
                     C![C.wide_button, C.border_on_focus],
@@ -355,7 +371,7 @@ impl Checkout {
                     ],
                     attrs! { At::Disabled => true },
                     "Slutför Köp",
-                ]
+                ] 
             },
             if let Some(message) = &self.confirm_button_message {
                 div![C![C.wide_button_message], message]

--- a/frontend/src/components/checkout.rs
+++ b/frontend/src/components/checkout.rs
@@ -340,18 +340,15 @@ impl Checkout {
                 if self.transaction_bundles.is_empty() {
                     button![
                         C![C.greyed_out, C.wide_button, C.border_on_focus],
-                        div![
-                            style! {
-                                St::Position => "absolute",
-                                St::MarginTop => "-0.25em",
-                                St::Filter => "invert(100%)",
-                            },
-                        ],
+                        div![style! {
+                            St::Position => "absolute",
+                            St::MarginTop => "-0.25em",
+                            St::Filter => "invert(100%)",
+                        },],
                         attrs! { At::Disabled => true },
                         "Slutför Köp",
-                    ] 
-                }
-                else {
+                    ]
+                } else {
                     button![
                         C![C.wide_button, C.border_on_focus],
                         simple_ev(Ev::Click, CheckoutMsg::ConfirmPurchase),

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -587,6 +587,7 @@ object {
  * https://github.com/mozdevs/cssremedy/issues/14
  */
 
+
 img,
 video {
 	max-width: 100%;
@@ -1277,3 +1278,7 @@ input[type=number] {
 	border: solid grey;
 }
 
+.greyed_out:disabled {
+	background-color: #a0a0a0;
+	cursor: default;
+}

--- a/frontend/static/styles.css
+++ b/frontend/static/styles.css
@@ -587,7 +587,6 @@ object {
  * https://github.com/mozdevs/cssremedy/issues/14
  */
 
-
 img,
 video {
 	max-width: 100%;


### PR DESCRIPTION
Add css class for greyed out buttons, and check in the view if the cart is empty

resolves #24 