### PR TITLE
backend: Add long polling for izettle bridge poll

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -11,6 +11,7 @@ mod schema;
 pub mod util;
 
 use crate::routes::rest;
+use crate::routes::rest::izettle::IZettleNotifier;
 use crate::util::{catchers, FileResponder};
 
 use clap::Parser;
@@ -50,6 +51,7 @@ async fn main() {
 
     let rocket = rocket::build()
         .manage(db_pool)
+        .manage(IZettleNotifier::default())
         .register("/", catchers())
         .attach(FileResponder {
             folder: "www",

--- a/backend/src/routes/rest/izettle/izettle_transaction.rs
+++ b/backend/src/routes/rest/izettle/izettle_transaction.rs
@@ -4,6 +4,7 @@ use crate::models::izettle_transaction::{
     NewIZettleTransactionItem, TRANSACTION_IN_PROGRESS,
 };
 use crate::models::transaction::object;
+use crate::routes::rest::izettle::IZettleNotifier;
 use crate::util::ser::{Ser, SerAccept};
 use crate::util::status_json::StatusJson as SJ;
 use diesel::{Connection, RunQueryDsl};
@@ -13,6 +14,7 @@ use rocket::{post, State};
 #[post("/izettle/client/transaction", data = "<transaction>")]
 pub async fn begin_izettle_transaction(
     db_pool: &State<DatabasePool>,
+    notifier: &State<IZettleNotifier>,
     accept: SerAccept,
     transaction: Json<object::NewTransaction>,
 ) -> Result<Ser<i32>, SJ> {
@@ -87,6 +89,8 @@ pub async fn begin_izettle_transaction(
                 .values(post_tran)
                 .execute(&connection)?;
         }
+
+        notifier.notify();
 
         Ok(accept.ser(transactions_id))
     })

--- a/backend/src/routes/rest/izettle/mod.rs
+++ b/backend/src/routes/rest/izettle/mod.rs
@@ -2,3 +2,53 @@ pub mod izettle_bridge_poll;
 pub mod izettle_bridge_result;
 pub mod izettle_transaction;
 pub mod izettle_transaction_poll;
+
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::time::timeout;
+
+/// A shared state struct that enables long-polling for izettle transactions
+#[derive(Default)]
+pub struct IZettleNotifier {
+    inner: Arc<InnerNotifier>,
+}
+
+#[derive(Default)]
+struct InnerNotifier {
+    ticker: AtomicU64,
+    notifier: Notify,
+}
+
+impl IZettleNotifier {
+    pub const TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Call notify to notify waiters that a pending transaction is ready
+    pub fn notify(&self) {
+        self.inner.ticker.fetch_add(1, Ordering::SeqCst);
+        self.inner.notifier.notify_waiters();
+    }
+
+    /// Wait for a maximum of `TIMEOUT` seconds for a pending transaction
+    ///
+    /// Returns true is the wait was ended by a call to notify, otherwise returns false
+    pub fn wait(&self) -> impl Future<Output = bool> + 'static {
+        let state = Arc::clone(&self.inner);
+
+        let start_tick = state.ticker.load(Ordering::SeqCst);
+
+        async move {
+            let notified = state.notifier.notified();
+
+            let has_ticked = || state.ticker.load(Ordering::SeqCst) != start_tick;
+
+            if has_ticked() {
+                true
+            } else {
+                timeout(Self::TIMEOUT, notified).await.is_ok() || has_ticked()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Seems to be working but needs to be more thoroughly tested.

The timeout settings for the bridge client could be set to something more generous as well.