### PR TITLE
Pedantic style changes

### DIFF
--- a/frontend/src/page/transactions.rs
+++ b/frontend/src/page/transactions.rs
@@ -336,6 +336,7 @@ impl TransactionsPage {
                     C![C.transactions_page_button_box],
                     button![
                         C![C.transactions_page_show_delete],
+                        C![C.space_above],
                         "Radera transaktioner?",
                         simple_ev(Ev::Click, TransactionsMsg::SetShowDelete(!self.show_delete)),
                     ],

--- a/frontend/src/page/transactions.rs
+++ b/frontend/src/page/transactions.rs
@@ -297,6 +297,7 @@ impl TransactionsPage {
                     ],
                     button![
                         C![C.wide_button],
+                        C![C.space_above],
                         "CSV (En rad per vara)",
                         simple_ev(
                             Ev::Click,

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1279,3 +1279,7 @@ input[type=number] {
 	background-color: #a0a0a0;
 	cursor: default;
 }
+
+.space_above {
+	margin-top: 0.5em;
+}

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1025,7 +1025,8 @@ video {
 
 .transactions_page_show_delete {
 	background-color: #fdc;
-	padding: 0.2rem;
+	padding: 0.2rem 0.5rem;
+    border: 1px dotted black;
 	border-radius: 0.2rem;
 	font-size: 1.2rem;
 	font-family: 'Ubuntu';

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1018,7 +1018,7 @@ video {
 	border-bottom: solid black;
 }
 
-.transaction_view:last-child {
+.transaction_view:last-of-type {
 	border-bottom: none;
 }
 

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1018,6 +1018,10 @@ video {
 	border-bottom: solid black;
 }
 
+.transaction_view:last-child {
+	border-bottom: none;
+}
+
 .transactions_page_button_box {
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
Small PR to fix some styling, this is all of course subjective changes so feel free to object to any/all of them.
Screenshots of the changes:

First commit, add spacing between buttons
![first-commit](https://user-images.githubusercontent.com/16452604/151593366-c90efdad-f1e7-4926-ad1b-058acca179c8.png)

Second commit, add border and some padding for the delete button
![second-commit](https://user-images.githubusercontent.com/16452604/151593515-a3b968d8-ac70-4968-a108-6c2efc4202f7.png)

Third commit, remove divider (bottom-border) for the last transaction in the list:
![third-commit](https://user-images.githubusercontent.com/16452604/151593616-5c5f1055-2c35-4e06-8eb1-165b4680c6b0.png)
