### PR TITLE
Now warns when transaction is too expensive

### DIFF
--- a/frontend/src/components/checkout.rs
+++ b/frontend/src/components/checkout.rs
@@ -8,7 +8,7 @@ use seed_fetcher::ResourceStore;
 use seed_fetcher::Resources;
 use std::collections::HashMap;
 use std::convert::TryInto;
-use strecklistan_api::book_account::BookAccount;
+use strecklistan_api::book_account::{BookAccount, BookAccountType};
 use strecklistan_api::{
     book_account::{BookAccountId, MasterAccounts},
     currency::{AbsCurrency, Currency},
@@ -49,7 +49,7 @@ pub struct Checkout {
     override_transaction_total: bool,
     pub debited_account: Option<BookAccountId>,
     pub confirm_button_message: Option<&'static str>,
-    pub disabled: bool,
+    pub waiting_for_izettle: bool,
     pub overpay_confirm_enabled: bool,
 }
 
@@ -80,7 +80,7 @@ impl Checkout {
                 .with_error_message(strings::INVALID_MONEY_MESSAGE_SHORT)
                 .with_input_kind("text"),
             override_transaction_total: false,
-            disabled: false,
+            waiting_for_izettle: false,
             confirm_button_message: None,
             overpay_confirm_enabled: false,
         }
@@ -102,7 +102,7 @@ impl Checkout {
             CheckoutMsg::ConfirmPurchase => {
                 self.remove_cleared_items();
                 if let Some(transaction) = self.build_transaction(rs) {
-                    self.disabled = true;
+                    self.waiting_for_izettle = true;
 
                     orders.perform_cmd(async move {
                         let result = async {
@@ -127,9 +127,10 @@ impl Checkout {
                         }
                     });
                 }
+                self.overpay_confirm_enabled = false;
             }
             CheckoutMsg::PurchaseSent { transaction_id } => {
-                self.disabled = false;
+                self.waiting_for_izettle = false;
                 log!("Posted transaction ID: ", transaction_id);
                 self.transaction_total_input.set_value(Default::default());
                 self.transaction_bundles = vec![];
@@ -141,18 +142,19 @@ impl Checkout {
                     ParsedInputMsg::FocusOut => {
                         if self.transaction_total_input.parsed().is_none() {
                             self.override_transaction_total = false;
-                            self.recompute_new_transaction_total();
+                            self.overpay_confirm_enabled = false
                         }
                     }
                     ParsedInputMsg::Input(_) => {
                         self.override_transaction_total = true;
+                        self.overpay_confirm_enabled = false
                     }
                     _ => {}
                 }
                 self.transaction_total_input.update(msg);
             }
             CheckoutMsg::AddItem { item_id, amount } => {
-                if !self.disabled {
+                if !self.waiting_for_izettle {
                     let item = res
                         .inventory
                         .get(&item_id)
@@ -258,35 +260,49 @@ impl Checkout {
             .into()
     }
 
-    pub fn set_debited(&mut self, account: &BookAccount) {
-        self.debited_account = Some(account.id);
+    pub fn set_debited(&mut self, account_id: BookAccountId) {
+        self.overpay_confirm_enabled = false;
+        self.debited_account = Some(account_id);
     }
 
     pub fn remove_cleared_items(&mut self) {
         self.transaction_bundles.retain(|bundle| bundle.change != 0);
     }
 
-    pub fn too_expensive(&self, res: &Res) -> bool {
-        let abs_currency: Currency = match self.transaction_total_input.parsed().copied() {
-            None => return false,
-            Some(abs_curr) => abs_curr.into(),
-        };
+    fn too_expensive(&self, res: &Res, book_account_id: &BookAccountId) -> bool {
+        let transaction_amount: Currency = self.transaction_amount();
 
-        let book_account_id = match self.debited_account {
-            None => {
-                // No account is selected
-                return false;
-            }
-            Some(balance) => balance,
-        };
+        let book_account = &res.book_accounts[book_account_id];
 
-        let book_account = &res.book_accounts[&book_account_id];
-
-        if book_account.balance < abs_currency {
-            return true;
+        match book_account.account_type {
+            BookAccountType::Liabilities => book_account.balance < transaction_amount,
+            _ => false,
         }
+    }
 
-        false
+    fn create_submit_button<M: 'static + Clone>(
+        show_penguin: bool,
+        style: Attrs,
+        on_click: Option<M>,
+    ) -> Node<M> {
+        button![
+            C![C.wide_button, C.border_on_focus],
+            IF![
+                show_penguin =>
+                div![
+                    C![C.penguin, C.penguin_small],
+                    style! {
+                        St::Position => "absolute",
+                        St::MarginTop => "-0.25em",
+                        St::Filter => "invert(100%)",
+                    },
+                ]
+            ],
+            style,
+            IF![on_click.is_none() => attrs! { At::Disabled => true }],
+            ev(Ev::Click, move |_| on_click),
+            "Slutför Köp",
+        ]
     }
 
     pub fn view(&self, rs: &ResourceStore) -> Node<CheckoutMsg> {
@@ -369,69 +385,48 @@ impl Checkout {
                     simple_ev(Ev::Click, CheckoutMsg::ClearCart),
                 ],
             ],
-            if !self.disabled {
-                if self.transaction_bundles.is_empty() || self.debited_account.is_none() {
-                    button![
-                        C![C.greyed_out, C.wide_button, C.border_on_focus],
-                        div![style! {
-                            St::Position => "absolute",
-                            St::MarginTop => "-0.25em",
-                            St::Filter => "invert(100%)",
-                        },],
-                        attrs! { At::Disabled => true },
-                        "Slutför Köp",
-                    ]
-                } else {
-                    if self.too_expensive(&res) {
-                        if self.overpay_confirm_enabled {
-                            // Double check if the user really wants to go through with the transaction.
-                            div![
-                                C![C.wide_button_foldout_container],
-                                button![
-                                    C![C.wide_button, C.border_on_focus, C.button_danger],
-                                    attrs! { At::Disabled => true },
-                                    "Slutför Köp",
-                                ],
-                                button![
-                                    C![
-                                        C.wide_button,
-                                        C.border_on_focus,
-                                        C.button_danger,
-                                        C.wide_button_foldout
-                                    ],
-                                    simple_ev(Ev::Click, CheckoutMsg::ConfirmPurchase),
-                                    "Godkänn överbetalning"
-                                ],
-                            ]
-                        } else {
-                            button![
-                                C![C.wide_button, C.border_on_focus, C.button_danger],
-                                simple_ev(Ev::Click, CheckoutMsg::OverpayConfirmPurchase),
-                                "Slutför Köp",
-                            ]
-                        }
-                    } else {
-                        button![
-                            C![C.wide_button, C.border_on_focus],
-                            simple_ev(Ev::Click, CheckoutMsg::ConfirmPurchase),
-                            "Slutför Köp",
-                        ]
-                    }
-                }
+            if self.waiting_for_izettle {
+                Self::create_submit_button(true, C![], None)
             } else {
-                button![
-                    C![C.wide_button, C.border_on_focus],
-                    div![
-                        C![C.penguin, C.penguin_small],
-                        style! {
-                            St::Position => "absolute",
-                            St::MarginTop => "-0.25em",
-                            St::Filter => "invert(100%)",
-                        },
-                    ],
-                    attrs! { At::Disabled => true },
-                    "Slutför Köp",
-                ]
+                match &self.debited_account {
+                    Some(account) if !self.transaction_bundles.is_empty() => {
+                        if self.too_expensive(&res, account) {
+                            if self.overpay_confirm_enabled {
+                                // Show foldout button to confirm overpay purchase.
+                                div![
+                                    C![C.wide_button_foldout_container],
+                                    Self::create_submit_button(false, C![C.button_danger], None),
+                                    button![
+                                        C![
+                                            C.wide_button,
+                                            C.border_on_focus,
+                                            C.button_danger,
+                                            C.wide_button_foldout
+                                        ],
+                                        simple_ev(Ev::Click, CheckoutMsg::ConfirmPurchase),
+                                        "Godkänn överbetalning"
+                                    ],
+                                ]
+                            } else {
+                                // Overpay purchase first confirmation.
+                                Self::create_submit_button(
+                                    false,
+                                    C![C.button_danger],
+                                    Some(CheckoutMsg::OverpayConfirmPurchase),
+                                )
+                            }
+                        } else {
+                            // Standard tillgodo purchase.
+                            Self::create_submit_button(
+                                false,
+                                C![],
+                                Some(CheckoutMsg::ConfirmPurchase),
+                            )
+                        }
+                    }
+                    // We don't have anything to purchase or not selected an account.
+                    _ => Self::create_submit_button(false, C![C.greyed_out], None),
+                }
             },
             if let Some(message) = &self.confirm_button_message {
                 div![C![C.wide_button_message], message]

--- a/frontend/src/page/store.rs
+++ b/frontend/src/page/store.rs
@@ -202,7 +202,10 @@ impl StorePage {
             StoreMsg::DebitSelect(selected) => {
                 self.selected_debit = Some(selected);
                 self.tillgodolista_search_string = String::new();
-                self.checkout.set_debited(selected.acc_id(&res));
+                match res.book_accounts.get(&selected.acc_id(&res)) {
+                    Some(acc) => self.checkout.set_debited(acc),
+                    None => error!("Failed to retrieve account {}", selected.acc_id(&res)),
+                }
             }
 
             StoreMsg::SearchInput(input) => {

--- a/frontend/src/page/store.rs
+++ b/frontend/src/page/store.rs
@@ -202,10 +202,7 @@ impl StorePage {
             StoreMsg::DebitSelect(selected) => {
                 self.selected_debit = Some(selected);
                 self.tillgodolista_search_string = String::new();
-                match res.book_accounts.get(&selected.acc_id(&res)) {
-                    Some(acc) => self.checkout.set_debited(acc),
-                    None => error!("Failed to retrieve account {}", selected.acc_id(&res)),
-                }
+                self.checkout.set_debited(selected.acc_id(&res));
             }
 
             StoreMsg::SearchInput(input) => {
@@ -276,7 +273,7 @@ impl StorePage {
                 message_title,
                 message_body,
             } => {
-                self.checkout.disabled = false;
+                self.checkout.waiting_for_izettle = false;
                 self.checkout.confirm_button_message = None;
                 orders.send_msg(Msg::Notification(NotificationMessage::ShowNotification {
                     duration_ms: 10000,
@@ -294,7 +291,7 @@ impl StorePage {
                         if self.selected_debit == Some(SelectedDebit::IZettleEPay) =>
                     {
                         if let Some(transaction) = self.checkout.build_transaction(rs) {
-                            self.checkout.disabled = true;
+                            self.checkout.waiting_for_izettle = true;
                             self.checkout.remove_cleared_items();
                             self.checkout.confirm_button_message =
                                 Some(strings::WAITING_FOR_PAYMENT);

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1097,6 +1097,20 @@ video {
 
 .wide_button:disabled {
 	background-color: #8ecda9;
+	cursor: default;
+}
+
+.button_danger {
+	background-color: #7b3434;
+}
+
+.button_danger:hover {
+	background-color: #6d0505;
+}
+
+.button_danger:disabled {
+	background-color: #Bb7474;
+	z-index: 2;
 }
 
 @keyframes slide_down {
@@ -1106,6 +1120,22 @@ video {
 	100% {
 		transform: translateY(0);
 	}
+}
+
+.wide_button_foldout {
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+	width: 80%;
+	margin-left: 10%;
+	padding-top: 0.1rem;
+	padding-bottom: 0.1rem;
+	animation: 0.7s ease-out 0s 1 slide_down;
+	z-index: 1;
+}
+
+.wide_button_foldout_container {
+	display: flex;
+	flex-direction: column;
 }
 
 .wide_button_message {


### PR DESCRIPTION
If ''tillgodo'' is used as payment method, the purchase button will now
be red when trying to complete a purchase that costs more than is
available on the account. 
![red-button-on-too-expensive-transaction](https://user-images.githubusercontent.com/16452604/151663898-571cb4fb-0d74-457d-ac39-8622cc134618.png)


When the button is pressed, a confirmation box
will also pop-up to ask if the user truly wants to go through with the
transaction.
![confirmation-on-too-expensive-transaction](https://user-images.githubusercontent.com/16452604/151663912-7d566a27-60ed-47a3-bfb0-e490e914116a.png)

There are a number of todos, mainly relating to error handling, when all of those are resolved this will be converted to a normal PR.

Solves #44
Also solves #22 although not in the way the issue requests.