### PR TITLE
Add the ability to handle inventory in bulk using CSVs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target*/
 
 # Trunk
 dist
+
+# Nix
+.direnv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,6 +2196,7 @@ version = "0.14.0"
 dependencies = [
  "chrono",
  "clap",
+ "csv",
  "diesel",
  "diesel-derive-enum",
  "diesel_migrations",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -36,8 +36,10 @@ strum = "0.20"
 strum_macros = "0.20"
 either = "1"
 clap = { version = "3.0.0-beta.4", features = ["derive", "env"] }
+csv = "1.4.0"
 
 
 [dependencies.strecklistan_api]
 path = "../common"
 features = ["diesel_impl"]
+

--- a/backend/example.env
+++ b/backend/example.env
@@ -6,6 +6,17 @@ RUN_MIGRATIONS=false
 ENABLE_STATIC_FILE_CACHE=false
 STATIC_FILES_MAX_AGE=0
 
+# CSV Import settings
+# Book account IDs used when importing inventory from CSV
+# Asset account (e.g., 1 = Bankkonto) - credited on stock increase, debited on decrease
+CSV_IMPORT_ASSET_ACCOUNT=1
+# Expense account (e.g., 4 = Inköp) - debited on stock increase, credited on decrease
+CSV_IMPORT_EXPENSE_ACCOUNT=4
+# Transaction description for CSV imports (default: "CSV Bulkhantering")
+CSV_IMPORT_TRANSACTION_DESCRIPTION=CSV Bulkhantering
+# Optional: separate transaction description for stock decreases (defaults to CSV_IMPORT_TRANSACTION_DESCRIPTION if not set)
+#CSV_IMPORT_TRANSACTION_DESCRIPTION_DECREASE=CSV Minskning
+
 # Tests are required to run sequentially
 # to avoid races within the database
 RUST_TEST_THREADS=1

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -67,6 +67,7 @@ async fn main() {
                 rest::event::get_event,
                 rest::event::get_event_range,
                 rest::inventory::get_items,
+                rest::inventory::generate_csv,
                 rest::inventory::post_item,
                 rest::inventory::put_item,
                 rest::inventory::delete_item,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -20,7 +20,7 @@ use dotenv::dotenv;
 use rocket::routes;
 use rocket_dyn_templates::Template;
 
-#[derive(Default, Parser)]
+#[derive(Default, Parser, Clone, Debug)]
 pub struct Opt {
     /// Database url specified as a postgres:// uri
     #[clap(long, short, env = "DATABASE_URL")]
@@ -37,6 +37,22 @@ pub struct Opt {
     /// Time until a cached static file must be invalidated
     #[clap(long, env = "STATIC_FILES_MAX_AGE", default_value_t)]
     max_age: usize,
+
+    /// Book account ID for CSV import asset account (e.g., Bankkonto)
+    #[clap(long, env = "CSV_IMPORT_ASSET_ACCOUNT")]
+    pub csv_import_asset_account: Option<i32>,
+
+    /// Book account ID for CSV import expense account (e.g., Inköp)
+    #[clap(long, env = "CSV_IMPORT_EXPENSE_ACCOUNT")]
+    pub csv_import_expense_account: Option<i32>,
+
+    /// Transaction description for CSV imports
+    #[clap(long, env = "CSV_IMPORT_TRANSACTION_DESCRIPTION", default_value = "CSV Bulkhantering")]
+    pub csv_import_transaction_description: String,
+
+    /// Transaction description for CSV imports when stock decreases (optional, falls back to CSV_IMPORT_TRANSACTION_DESCRIPTION)
+    #[clap(long, env = "CSV_IMPORT_TRANSACTION_DESCRIPTION_DECREASE")]
+    pub csv_import_transaction_description_decrease: Option<String>,
 }
 
 #[rocket::main]
@@ -51,14 +67,19 @@ async fn main() {
         database::run_migrations(&db_pool);
     }
 
+    // Extract values we need before moving opt
+    let static_file_cache = opt.static_file_cache;
+    let max_age = opt.max_age;
+
     let rocket = rocket::build()
         .manage(db_pool)
+        .manage(opt)
         .manage(IZettleNotifier::default())
         .register("/", catchers())
         .attach(FileResponder {
             folder: "www",
-            enable_cache: opt.static_file_cache,
-            max_age: opt.max_age,
+            enable_cache: static_file_cache,
+            max_age,
         })
         .attach(Template::fairing())
         .mount(
@@ -67,7 +88,6 @@ async fn main() {
                 rest::event::get_event,
                 rest::event::get_event_range,
                 rest::inventory::get_items,
-                rest::inventory::generate_csv,
                 rest::inventory::post_item,
                 rest::inventory::put_item,
                 rest::inventory::delete_item,
@@ -76,6 +96,8 @@ async fn main() {
                 rest::inventory::put_bundle,
                 rest::inventory::post_bundle,
                 rest::inventory::delete_inventory_bundle,
+                rest::inventory::generate_csv,
+                rest::inventory::update_inventory_from_csv,
                 rest::transaction::get_transactions,
                 rest::transaction::post_transaction,
                 rest::transaction::delete_transaction,

--- a/backend/src/models/inventory.rs
+++ b/backend/src/models/inventory.rs
@@ -32,7 +32,7 @@ pub struct NewInventoryBundleItem {
     pub item_id: i32,
 }
 
-#[derive(Queryable, Serialize)]
+#[derive(Queryable, Serialize, Deserialize, Debug, PartialEq)]
 pub struct InventoryCSVExportItem {
     pub name: String,
     pub price: Option<i32>,

--- a/backend/src/models/inventory.rs
+++ b/backend/src/models/inventory.rs
@@ -32,9 +32,27 @@ pub struct NewInventoryBundleItem {
     pub item_id: i32,
 }
 
-#[derive(Queryable, Serialize, Deserialize, Debug, PartialEq)]
-pub struct InventoryCSVExportItem {
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct InventoryCSVItem {
     pub name: String,
-    pub price: Option<i32>,
+    pub price: Option<f64>,
     pub stock: i32,
 }
+
+impl InventoryCSVItem {
+    /// Create from database values (price in öre)
+    pub fn from_db(name: String, price_ore: Option<i32>, stock: i32) -> Self {
+        InventoryCSVItem {
+            name,
+            price: price_ore.map(|p| p as f64 / 100.0),
+            stock,
+        }
+    }
+
+    /// Convert price from kronor to öre for database storage
+    pub fn price_in_ore(&self) -> Option<i32> {
+        self.price.map(|p| (p * 100.0).round() as i32)
+    }
+}
+
+

--- a/backend/src/models/inventory.rs
+++ b/backend/src/models/inventory.rs
@@ -31,3 +31,10 @@ pub struct NewInventoryBundleItem {
     pub bundle_id: i32,
     pub item_id: i32,
 }
+
+#[derive(Queryable, Serialize)]
+pub struct InventoryCSVExportItem {
+    pub name: String,
+    pub price: Option<i32>,
+    pub stock: i32,
+}

--- a/backend/src/routes/rest/inventory.rs
+++ b/backend/src/routes/rest/inventory.rs
@@ -1,6 +1,6 @@
 use crate::database::DatabasePool;
 use crate::models::inventory::{
-    InventoryBundle as InventoryBundleRel, InventoryBundleItem, InventoryCSVExportItem,
+    InventoryBundle as InventoryBundleRel, InventoryBundleItem, InventoryCSVItem,
     NewInventoryBundle as NewInventoryBundleRel, NewInventoryBundleItem,
 };
 use crate::util::CsvResponse;
@@ -271,13 +271,15 @@ pub fn generate_csv<'r>(db_pool: &'_ State<DatabasePool>) -> Result<CsvResponse<
     let mut connection = db_pool.inner().get()?;
 
     use crate::schema::views::inventory_stock::dsl::{inventory_stock, name, price, stock};
-    let items: Vec<InventoryCSVExportItem> = inventory_stock
+    let items: Vec<(String, Option<i32>, i32)> = inventory_stock
         .select((name, price, stock))
         .load(&mut connection)?;
 
     let mut wtr = csv::Writer::from_writer(vec![]);
-    for item in items {
-        wtr.serialize(item).map_err(|e| {
+    // Convert prices from öre to kronor so that the CSV is nicer to use
+    for (item_name, price_ore, item_stock) in items {
+        let csv_item = InventoryCSVItem::from_db(item_name, price_ore, item_stock);
+        wtr.serialize(csv_item).map_err(|e| {
             SJ::new(
                 Status::InternalServerError,
                 format!("Failed to serialize CSV: {}", e),
@@ -362,7 +364,7 @@ pub async fn update_inventory_from_csv(
         ));
     }
 
-    let items: Vec<InventoryCSVExportItem> = rdr
+    let items: Vec<InventoryCSVItem> = rdr
         .deserialize()
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| SJ::new(Status::BadRequest, format!("Invalid CSV data: {}", e)))?;
@@ -383,11 +385,14 @@ pub async fn update_inventory_from_csv(
                 .first(connection)
                 .optional()?;
 
+            // Convert price from kronor to öre for database operations
+            let price_ore = csv_item.price_in_ore();
+
             let (item_id, current_stock) = if let Some(existing_item) = existing {
-                if csv_item.price.is_some() && csv_item.price != existing_item.price {
+                if price_ore.is_some() && price_ore != existing_item.price {
                     diesel::update(inv_dsl::inventory)
                         .filter(inv_dsl::id.eq(existing_item.id))
-                        .set(inv_dsl::price.eq(csv_item.price))
+                        .set(inv_dsl::price.eq(price_ore))
                         .execute(connection)?;
                 }
                 (existing_item.id, existing_item.stock)
@@ -395,7 +400,7 @@ pub async fn update_inventory_from_csv(
                 let new_id: InventoryItemId = diesel::insert_into(inv_dsl::inventory)
                     .values((
                         inv_dsl::name.eq(&csv_item.name),
-                        inv_dsl::price.eq(csv_item.price),
+                        inv_dsl::price.eq(price_ore),
                     ))
                     .returning(inv_dsl::id)
                     .get_result(connection)?;
@@ -405,7 +410,7 @@ pub async fn update_inventory_from_csv(
             let stock_change = csv_item.stock - current_stock;
 
             if stock_change != 0 {
-                stock_adjustments.push((item_id, csv_item.name, csv_item.price, stock_change));
+                stock_adjustments.push((item_id, csv_item.name, price_ore, stock_change));
             }
         }
 
@@ -498,7 +503,7 @@ pub async fn update_inventory_from_csv(
             )?;
         }
 
-        // Refresh the materialized view to update stock counts
+        // Refresh the materialized view to update stock counts and price
         diesel::sql_query("REFRESH MATERIALIZED VIEW inventory_stock").execute(connection)?;
 
         Ok(Status::Ok.into())

--- a/backend/src/routes/rest/inventory.rs
+++ b/backend/src/routes/rest/inventory.rs
@@ -293,14 +293,11 @@ pub fn generate_csv<'r>(db_pool: &'_ State<DatabasePool>) -> Result<CsvResponse<
         )
     })?;
 
-    Ok(CsvResponse {
-        data,
-        filename: "inventory.csv",
-    })
+    Ok(CsvResponse::new(data, "inventory.csv"))
 }
 
 #[derive(rocket::FromForm)]
-struct CsvUpload<'r> {
+pub struct CsvUpload<'r> {
     file: rocket::fs::TempFile<'r>,
 }
 
@@ -339,18 +336,15 @@ pub async fn update_inventory_from_csv(
         )
     })?;
 
-    let mut csv_string = String::new();
-    csv_data
-        .read_to_string(&mut csv_string)
-        .await
-        .map_err(|_| {
-            SJ::new(
-                Status::InternalServerError,
-                "Failed to parse CSV content".to_string(),
-            )
-        })?;
+    let mut csv_bytes = Vec::new();
+    csv_data.read_to_end(&mut csv_bytes).await.map_err(|_| {
+        SJ::new(
+            Status::InternalServerError,
+            "Failed to read file".to_string(),
+        )
+    })?;
 
-    let mut rdr = csv::Reader::from_reader(csv_string.as_bytes());
+    let mut rdr = csv::Reader::from_reader(csv_bytes.as_slice());
     let headers = rdr
         .headers()
         .map_err(|_| SJ::new(Status::BadRequest, "Invalid CSV format".to_string()))?;
@@ -414,70 +408,72 @@ pub async fn update_inventory_from_csv(
             }
         }
 
-        // Create a single transaction for all stock adjustments if there are any
         if !stock_adjustments.is_empty() {
             // Split adjustments into positive and negative changes
-            let (positive_adjustments, negative_adjustments): (Vec<_>, Vec<_>) =
-                stock_adjustments.into_iter()
-                    .partition(|(_, _, _, change)| *change > 0);
+            let (positive_adjustments, negative_adjustments): (Vec<_>, Vec<_>) = stock_adjustments
+                .into_iter()
+                .partition(|(_, _, _, change)| *change > 0);
 
             // Helper function to create a transaction with bundles
-            let create_transaction = |connection: &mut PgConnection,
-                                     adjustments: Vec<(InventoryItemId, String, Option<i32>, i32)>,
-                                     debited: i32,
-                                     credited: i32,
-                                     description: &str| -> Result<(), SJ> {
-                if adjustments.is_empty() {
-                    return Ok(());
-                }
+            let create_transaction =
+                |connection: &mut PgConnection,
+                 adjustments: Vec<(InventoryItemId, String, Option<i32>, i32)>,
+                 debited: i32,
+                 credited: i32,
+                 description: &str|
+                 -> Result<(), SJ> {
+                    if adjustments.is_empty() {
+                        return Ok(());
+                    }
 
-                let total_amount: i32 = adjustments.iter()
-                    .filter_map(|(_, _, price, stock_change)| {
-                        price.map(|p| p * stock_change.abs())
-                    })
-                    .sum();
+                    let total_amount: i32 = adjustments
+                        .iter()
+                        .filter_map(|(_, _, price, stock_change)| {
+                            price.map(|p| p * stock_change.abs())
+                        })
+                        .sum();
 
-                let transaction_id = {
-                    use crate::schema::tables::transactions::dsl as trans_dsl;
-                    diesel::insert_into(trans_dsl::transactions)
-                        .values((
-                            trans_dsl::description.eq(Some(description.to_string())),
-                            trans_dsl::debited_account.eq(debited),
-                            trans_dsl::credited_account.eq(credited),
-                            trans_dsl::amount.eq(total_amount),
-                        ))
-                        .returning(trans_dsl::id)
-                        .get_result::<TransactionId>(connection)?
-                };
-
-                // Create bundles for each item adjustment
-                for (item_id, name, price, stock_change) in adjustments {
-                    let bundle_id = {
-                        use crate::schema::tables::transaction_bundles::dsl as bundle_dsl;
-                        diesel::insert_into(bundle_dsl::transaction_bundles)
+                    let transaction_id = {
+                        use crate::schema::tables::transactions::dsl as trans_dsl;
+                        diesel::insert_into(trans_dsl::transactions)
                             .values((
-                                bundle_dsl::transaction_id.eq(transaction_id),
-                                bundle_dsl::description.eq(Some(name)),
-                                bundle_dsl::price.eq(price),
-                                bundle_dsl::change.eq(stock_change),
+                                trans_dsl::description.eq(Some(description.to_string())),
+                                trans_dsl::debited_account.eq(debited),
+                                trans_dsl::credited_account.eq(credited),
+                                trans_dsl::amount.eq(total_amount),
                             ))
-                            .returning(bundle_dsl::id)
-                            .get_result::<i32>(connection)?
+                            .returning(trans_dsl::id)
+                            .get_result::<TransactionId>(connection)?
                     };
 
-                    {
-                        use crate::schema::tables::transaction_items::dsl as item_dsl;
-                        diesel::insert_into(item_dsl::transaction_items)
-                            .values((
-                                item_dsl::bundle_id.eq(bundle_id),
-                                item_dsl::item_id.eq(item_id),
-                            ))
-                            .execute(connection)?;
-                    }
-                }
+                    // Create bundles for each item adjustment
+                    for (item_id, name, price, stock_change) in adjustments {
+                        let bundle_id = {
+                            use crate::schema::tables::transaction_bundles::dsl as bundle_dsl;
+                            diesel::insert_into(bundle_dsl::transaction_bundles)
+                                .values((
+                                    bundle_dsl::transaction_id.eq(transaction_id),
+                                    bundle_dsl::description.eq(Some(name)),
+                                    bundle_dsl::price.eq(price),
+                                    bundle_dsl::change.eq(stock_change),
+                                ))
+                                .returning(bundle_dsl::id)
+                                .get_result::<i32>(connection)?
+                        };
 
-                Ok(())
-            };
+                        {
+                            use crate::schema::tables::transaction_items::dsl as item_dsl;
+                            diesel::insert_into(item_dsl::transaction_items)
+                                .values((
+                                    item_dsl::bundle_id.eq(bundle_id),
+                                    item_dsl::item_id.eq(item_id),
+                                ))
+                                .execute(connection)?;
+                        }
+                    }
+
+                    Ok(())
+                };
 
             // Create transaction for positive changes
             create_transaction(
@@ -485,12 +481,13 @@ pub async fn update_inventory_from_csv(
                 positive_adjustments,
                 expense_account,
                 asset_account,
-                &config.csv_import_transaction_description
+                &config.csv_import_transaction_description,
             )?;
 
             // Create transaction for negative changes
             // Use separate description if provided, otherwise use the same as increases
-            let decrease_description = config.csv_import_transaction_description_decrease
+            let decrease_description = config
+                .csv_import_transaction_description_decrease
                 .as_ref()
                 .unwrap_or(&config.csv_import_transaction_description);
 
@@ -499,7 +496,7 @@ pub async fn update_inventory_from_csv(
                 negative_adjustments,
                 asset_account,
                 expense_account,
-                decrease_description
+                decrease_description,
             )?;
         }
 

--- a/backend/src/routes/rest/inventory.rs
+++ b/backend/src/routes/rest/inventory.rs
@@ -1,11 +1,15 @@
 use crate::database::DatabasePool;
-use crate::models::inventory::{InventoryBundle as InventoryBundleRel, InventoryBundleItem, InventoryCSVExportItem, NewInventoryBundle as NewInventoryBundleRel, NewInventoryBundleItem};
+use crate::models::inventory::{
+    InventoryBundle as InventoryBundleRel, InventoryBundleItem, InventoryCSVExportItem,
+    NewInventoryBundle as NewInventoryBundleRel, NewInventoryBundleItem,
+};
+use crate::util::CsvResponse;
 use crate::util::ser::{Ser, SerAccept};
 use crate::util::status_json::StatusJson as SJ;
-use crate::util::CsvResponse;
 use chrono::Utc;
 use diesel::prelude::*;
 use itertools::Itertools;
+use rocket::form::Form;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::{State, delete, get, post, put};
@@ -16,6 +20,7 @@ use strecklistan_api::inventory::{
     NewInventoryBundle as NewInventoryBundleObj, NewInventoryItem,
 };
 use strecklistan_api::transaction::TransactionId;
+use tokio::io::AsyncReadExt;
 
 #[get("/inventory/items")]
 pub fn get_items(
@@ -32,37 +37,6 @@ pub fn get_items(
             .map(|item: InventoryItemStock| (item.id, item))
             .collect(),
     ))
-}
-
-#[get("/inventory/csv")]
-pub fn generate_csv<'r>(
-    db_pool: &'_ State<DatabasePool>,
-) -> Result<CsvResponse<'_>, SJ> {
-    let mut connection = db_pool.inner().get()?;
-
-    use crate::schema::views::inventory_stock::dsl::{inventory_stock, name, price, stock};
-    let items: Vec<InventoryCSVExportItem> = inventory_stock.select((name, price, stock)).load(&mut connection)?;
-
-    let mut wtr = csv::Writer::from_writer(vec![]);
-    for item in items {
-        wtr.serialize(item).map_err(|e| {
-            SJ::new(
-                Status::InternalServerError,
-                format!("Failed to serialize CSV: {}", e),
-            )
-        })?;
-    }
-    let data = wtr.into_inner().map_err(|e| {
-        SJ::new(
-            Status::InternalServerError,
-            format!("Failed to finalize CSV: {}", e),
-        )
-    })?;
-
-    Ok(CsvResponse {
-        data,
-        filename: "inventory.csv",
-    })
 }
 
 #[post("/inventory/item", data = "<item>")]
@@ -287,6 +261,245 @@ pub fn delete_inventory_bundle(
                 .get_result(connection)?;
             assert_eq!(deleted_id, id);
         }
+
+        Ok(Status::Ok.into())
+    })
+}
+
+#[get("/inventory/csv")]
+pub fn generate_csv<'r>(db_pool: &'_ State<DatabasePool>) -> Result<CsvResponse<'_>, SJ> {
+    let mut connection = db_pool.inner().get()?;
+
+    use crate::schema::views::inventory_stock::dsl::{inventory_stock, name, price, stock};
+    let items: Vec<InventoryCSVExportItem> = inventory_stock
+        .select((name, price, stock))
+        .load(&mut connection)?;
+
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    for item in items {
+        wtr.serialize(item).map_err(|e| {
+            SJ::new(
+                Status::InternalServerError,
+                format!("Failed to serialize CSV: {}", e),
+            )
+        })?;
+    }
+    let data = wtr.into_inner().map_err(|e| {
+        SJ::new(
+            Status::InternalServerError,
+            format!("Failed to finalize CSV: {}", e),
+        )
+    })?;
+
+    Ok(CsvResponse {
+        data,
+        filename: "inventory.csv",
+    })
+}
+
+#[derive(rocket::FromForm)]
+struct CsvUpload<'r> {
+    file: rocket::fs::TempFile<'r>,
+}
+
+#[put("/inventory/csv/update", data = "<form>")]
+pub async fn update_inventory_from_csv(
+    db_pool: &State<DatabasePool>,
+    config: &State<crate::Opt>,
+    mut form: Form<CsvUpload<'_>>,
+) -> Result<SJ, SJ> {
+    let asset_account = config.csv_import_asset_account.ok_or_else(|| {
+        SJ::new(
+            Status::InternalServerError,
+            "CSV_IMPORT_ASSET_ACCOUNT is not configured".to_string(),
+        )
+    })?;
+
+    let expense_account = config.csv_import_expense_account.ok_or_else(|| {
+        SJ::new(
+            Status::InternalServerError,
+            "CSV_IMPORT_EXPENSE_ACCOUNT is not configured".to_string(),
+        )
+    })?;
+
+    let file = &mut form.file;
+    if !file.content_type().map_or(false, |ct| ct.is_csv()) {
+        return Err(SJ::new(
+            Status::BadRequest,
+            "Invalid file: must be a CSV".to_string(),
+        ));
+    }
+
+    let mut csv_data = file.open().await.map_err(|_| {
+        SJ::new(
+            Status::InternalServerError,
+            "Failed to read file".to_string(),
+        )
+    })?;
+
+    let mut csv_string = String::new();
+    csv_data
+        .read_to_string(&mut csv_string)
+        .await
+        .map_err(|_| {
+            SJ::new(
+                Status::InternalServerError,
+                "Failed to parse CSV content".to_string(),
+            )
+        })?;
+
+    let mut rdr = csv::Reader::from_reader(csv_string.as_bytes());
+    let headers = rdr
+        .headers()
+        .map_err(|_| SJ::new(Status::BadRequest, "Invalid CSV format".to_string()))?;
+
+    // I can't figure out how to compare csv::StringRecord with something that is not allocated...
+    // so we allocate a vec here. Consider optimizing later if performance is an issue.
+    if headers != vec!["name", "price", "stock"] {
+        return Err(SJ::new(
+            Status::BadRequest,
+            "Invalid CSV headers: expected 'name,price,stock'".to_string(),
+        ));
+    }
+
+    let items: Vec<InventoryCSVExportItem> = rdr
+        .deserialize()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| SJ::new(Status::BadRequest, format!("Invalid CSV data: {}", e)))?;
+
+    let mut connection = db_pool.inner().get()?;
+
+    connection.transaction::<_, SJ, _>(|connection| {
+        use crate::schema::tables::inventory::dsl as inv_dsl;
+        use crate::schema::views::inventory_stock::dsl as stock_dsl;
+
+        // Collect all items that need stock adjustments
+        let mut stock_adjustments: Vec<(InventoryItemId, String, Option<i32>, i32)> = Vec::new();
+
+        for csv_item in items {
+            let existing: Option<InventoryItemStock> = stock_dsl::inventory_stock
+                .filter(stock_dsl::name.eq(&csv_item.name))
+                .filter(stock_dsl::deleted_at.is_null())
+                .first(connection)
+                .optional()?;
+
+            let (item_id, current_stock) = if let Some(existing_item) = existing {
+                if csv_item.price.is_some() && csv_item.price != existing_item.price {
+                    diesel::update(inv_dsl::inventory)
+                        .filter(inv_dsl::id.eq(existing_item.id))
+                        .set(inv_dsl::price.eq(csv_item.price))
+                        .execute(connection)?;
+                }
+                (existing_item.id, existing_item.stock)
+            } else {
+                let new_id: InventoryItemId = diesel::insert_into(inv_dsl::inventory)
+                    .values((
+                        inv_dsl::name.eq(&csv_item.name),
+                        inv_dsl::price.eq(csv_item.price),
+                    ))
+                    .returning(inv_dsl::id)
+                    .get_result(connection)?;
+                (new_id, 0)
+            };
+
+            let stock_change = csv_item.stock - current_stock;
+
+            if stock_change != 0 {
+                stock_adjustments.push((item_id, csv_item.name, csv_item.price, stock_change));
+            }
+        }
+
+        // Create a single transaction for all stock adjustments if there are any
+        if !stock_adjustments.is_empty() {
+            // Split adjustments into positive and negative changes
+            let (positive_adjustments, negative_adjustments): (Vec<_>, Vec<_>) =
+                stock_adjustments.into_iter()
+                    .partition(|(_, _, _, change)| *change > 0);
+
+            // Helper function to create a transaction with bundles
+            let create_transaction = |connection: &mut PgConnection,
+                                     adjustments: Vec<(InventoryItemId, String, Option<i32>, i32)>,
+                                     debited: i32,
+                                     credited: i32,
+                                     description: &str| -> Result<(), SJ> {
+                if adjustments.is_empty() {
+                    return Ok(());
+                }
+
+                let total_amount: i32 = adjustments.iter()
+                    .filter_map(|(_, _, price, stock_change)| {
+                        price.map(|p| p * stock_change.abs())
+                    })
+                    .sum();
+
+                let transaction_id = {
+                    use crate::schema::tables::transactions::dsl as trans_dsl;
+                    diesel::insert_into(trans_dsl::transactions)
+                        .values((
+                            trans_dsl::description.eq(Some(description.to_string())),
+                            trans_dsl::debited_account.eq(debited),
+                            trans_dsl::credited_account.eq(credited),
+                            trans_dsl::amount.eq(total_amount),
+                        ))
+                        .returning(trans_dsl::id)
+                        .get_result::<TransactionId>(connection)?
+                };
+
+                // Create bundles for each item adjustment
+                for (item_id, name, price, stock_change) in adjustments {
+                    let bundle_id = {
+                        use crate::schema::tables::transaction_bundles::dsl as bundle_dsl;
+                        diesel::insert_into(bundle_dsl::transaction_bundles)
+                            .values((
+                                bundle_dsl::transaction_id.eq(transaction_id),
+                                bundle_dsl::description.eq(Some(name)),
+                                bundle_dsl::price.eq(price),
+                                bundle_dsl::change.eq(stock_change),
+                            ))
+                            .returning(bundle_dsl::id)
+                            .get_result::<i32>(connection)?
+                    };
+
+                    {
+                        use crate::schema::tables::transaction_items::dsl as item_dsl;
+                        diesel::insert_into(item_dsl::transaction_items)
+                            .values((
+                                item_dsl::bundle_id.eq(bundle_id),
+                                item_dsl::item_id.eq(item_id),
+                            ))
+                            .execute(connection)?;
+                    }
+                }
+
+                Ok(())
+            };
+
+            // Create transaction for positive changes
+            create_transaction(
+                connection,
+                positive_adjustments,
+                expense_account,
+                asset_account,
+                &config.csv_import_transaction_description
+            )?;
+
+            // Create transaction for negative changes
+            // Use separate description if provided, otherwise use the same as increases
+            let decrease_description = config.csv_import_transaction_description_decrease
+                .as_ref()
+                .unwrap_or(&config.csv_import_transaction_description);
+
+            create_transaction(
+                connection,
+                negative_adjustments,
+                asset_account,
+                expense_account,
+                decrease_description
+            )?;
+        }
+
+        // Refresh the materialized view to update stock counts
+        diesel::sql_query("REFRESH MATERIALIZED VIEW inventory_stock").execute(connection)?;
 
         Ok(Status::Ok.into())
     })

--- a/backend/src/routes/rest/inventory.rs
+++ b/backend/src/routes/rest/inventory.rs
@@ -1,10 +1,8 @@
 use crate::database::DatabasePool;
-use crate::models::inventory::{
-    InventoryBundle as InventoryBundleRel, InventoryBundleItem,
-    NewInventoryBundle as NewInventoryBundleRel, NewInventoryBundleItem,
-};
+use crate::models::inventory::{InventoryBundle as InventoryBundleRel, InventoryBundleItem, InventoryCSVExportItem, NewInventoryBundle as NewInventoryBundleRel, NewInventoryBundleItem};
 use crate::util::ser::{Ser, SerAccept};
 use crate::util::status_json::StatusJson as SJ;
+use crate::util::CsvResponse;
 use chrono::Utc;
 use diesel::prelude::*;
 use itertools::Itertools;
@@ -34,6 +32,37 @@ pub fn get_items(
             .map(|item: InventoryItemStock| (item.id, item))
             .collect(),
     ))
+}
+
+#[get("/inventory/csv")]
+pub fn generate_csv<'r>(
+    db_pool: &'_ State<DatabasePool>,
+) -> Result<CsvResponse<'_>, SJ> {
+    let mut connection = db_pool.inner().get()?;
+
+    use crate::schema::views::inventory_stock::dsl::{inventory_stock, name, price, stock};
+    let items: Vec<InventoryCSVExportItem> = inventory_stock.select((name, price, stock)).load(&mut connection)?;
+
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    for item in items {
+        wtr.serialize(item).map_err(|e| {
+            SJ::new(
+                Status::InternalServerError,
+                format!("Failed to serialize CSV: {}", e),
+            )
+        })?;
+    }
+    let data = wtr.into_inner().map_err(|e| {
+        SJ::new(
+            Status::InternalServerError,
+            format!("Failed to finalize CSV: {}", e),
+        )
+    })?;
+
+    Ok(CsvResponse {
+        data,
+        filename: "inventory.csv",
+    })
 }
 
 #[post("/inventory/item", data = "<item>")]

--- a/backend/src/util/csv_response.rs
+++ b/backend/src/util/csv_response.rs
@@ -3,8 +3,14 @@ use rocket::{Request, Response};
 use rocket::response::Responder;
 
 pub struct CsvResponse<'a> {
-    pub data: Vec<u8>,
-    pub filename: &'a str,
+    data: Vec<u8>,
+    filename: &'a str,
+}
+
+impl <'a> CsvResponse<'a> {
+    pub fn new(data: Vec<u8>, filename: &'a str) -> Self {
+        CsvResponse { data, filename }
+    }
 }
 
 impl<'r, 'a> Responder<'r, 'static> for CsvResponse<'a> {

--- a/backend/src/util/csv_response.rs
+++ b/backend/src/util/csv_response.rs
@@ -1,0 +1,21 @@
+use rocket::http::ContentType;
+use rocket::{Request, Response};
+use rocket::response::Responder;
+
+pub struct CsvResponse<'a> {
+    pub data: Vec<u8>,
+    pub filename: &'a str,
+}
+
+impl<'r, 'a> Responder<'r, 'static> for CsvResponse<'a> {
+    fn respond_to(self, _request: &'_ Request<'_>) -> rocket::response::Result<'static> {
+        Response::build()
+            .header(ContentType::CSV)
+            .raw_header(
+                "Content-Disposition",
+                format!("attachment; filename=\"{}\"", self.filename),
+            )
+            .sized_body(self.data.len(), std::io::Cursor::new(self.data))
+            .ok()
+    }
+}

--- a/backend/src/util/mod.rs
+++ b/backend/src/util/mod.rs
@@ -4,7 +4,7 @@ pub mod ord;
 pub mod ser;
 pub mod status_json;
 pub mod testing;
-
+pub mod csv_response;
 // Re-exporting module members for convenience
 
 #[doc(inline)]
@@ -18,3 +18,6 @@ pub use self::file::responder::FileResponder;
 
 #[doc(inline)]
 pub use self::file::cached_file::CachedFile;
+
+#[doc(inline)]
+pub use csv_response::CsvResponse;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767116409,
+        "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cad22e7d996aea55ecab064e84834289143e44a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767408057,
+        "narHash": "sha256-0TD2PNTt6olOonFgcvZJcNGiU3x5cX+RMzrfWfHB9Jw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "294198315a13d6d130565ad08e97685df7b0d458",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "Strecklistan - A simple web-shop";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+            "clippy"
+            "rustfmt"
+          ];
+          targets = [ "wasm32-unknown-unknown" ];
+        };
+
+        # Dependencies for the backend (Diesel/Postgres + OpenSSL)
+        backendDeps = with pkgs; [
+          openssl
+          postgresql_17
+          pkg-config
+        ];
+
+        # Dependencies for the frontend (Trunk/Wasm)
+        frontendDeps = with pkgs; [
+          trunk
+          wasm-pack
+          wasm-bindgen-cli
+        ];
+
+        # General development tools
+        devTools = with pkgs; [
+          rustToolchain
+          cargo-make
+          diesel-cli
+          bacon
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "strecklistan-dev";
+
+          nativeBuildInputs = devTools ++ backendDeps ++ frontendDeps;
+
+          shellHook = ''
+            export DATABASE_URL="postgres://postgres:password@localhost:5432/strecklistan"
+          '';
+        };
+      }
+    );
+}

--- a/frontend/src/notification_manager.rs
+++ b/frontend/src/notification_manager.rs
@@ -27,6 +27,13 @@ pub struct NotificationManager {
 pub struct Notification {
     pub title: String,
     pub body: Option<String>,
+    pub notification_type: NotificationType,
+}
+
+#[derive(Debug, Clone)]
+pub enum NotificationType {
+    Error,
+    Success,
 }
 
 impl NotificationManager {
@@ -36,6 +43,10 @@ impl NotificationManager {
             self.notifications.iter().map(|(id, notification)| {
                 div![
                     C![C.notification],
+                    match notification.notification_type {
+                        NotificationType::Error => C![C.notification_error],
+                        NotificationType::Success => C![C.notification_success],
+                    },
                     p![C![C.notification_title], &notification.title],
                     if let Some(body) = &notification.body {
                         p![C![C.notification_body], &body]

--- a/frontend/src/page/deposit.rs
+++ b/frontend/src/page/deposit.rs
@@ -3,7 +3,7 @@ use crate::components::izettle_pay::{IZettlePay, IZettlePayErr, IZettlePayMsg};
 use crate::components::parsed_input::{ParsedInput, ParsedInputMsg};
 use crate::fuzzy_search::{FuzzyScore, FuzzySearch};
 use crate::generated::css_classes::C;
-use crate::notification_manager::{Notification, NotificationMessage};
+use crate::notification_manager::{Notification, NotificationMessage, NotificationType};
 use crate::page::loading::Loading;
 use crate::strings;
 use crate::util::simple_ev;
@@ -228,6 +228,7 @@ impl DepositionPage {
                             .amount_input
                             .parsed()
                             .map(|value| format!("{}:-", value)),
+                        notification_type: NotificationType::Success,
                     },
                 }));
 
@@ -248,6 +249,7 @@ impl DepositionPage {
                     notification: Notification {
                         title: message_title,
                         body: message_body,
+                        notification_type: NotificationType::Error,
                     },
                 }));
             }

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -35,10 +35,12 @@ pub enum InventoryMsg {
 
     ItemsChanged,
     BundlesChanged,
+    BulkChanged,
     ServerError(String),
 
     BundleInput(Field, InventoryBundleId, ParsedInputMsg),
     ItemInput(Field, InventoryItemId, ParsedInputMsg),
+    UploadCsv(web_sys::File),
 }
 
 pub struct InventoryPage {
@@ -265,6 +267,9 @@ impl InventoryPage {
             InventoryMsg::BundlesChanged => {
                 rs.mark_as_dirty(Res::bundles_url(), orders);
             }
+            InventoryMsg::BulkChanged => {
+                rs.mark_as_dirty(Res::items_url(), orders);
+            }
             InventoryMsg::ServerError(message) => {
                 orders.send_msg(Msg::Notification(NotificationMessage::ShowNotification {
                     duration_ms: 10000,
@@ -289,6 +294,42 @@ impl InventoryPage {
                     Field::Price => row.map(|row| row.price.update(msg)),
                     Field::Image => row.map(|row| row.image.update(msg)),
                 };
+            }
+            InventoryMsg::UploadCsv(file) => {
+                orders_local.perform_cmd(async move {
+                    let form_data = match web_sys::FormData::new() {
+                        Ok(fd) => fd,
+                        Err(_) => {
+                            gloo_console::error!("Failed to create FormData");
+                            return InventoryMsg::ServerError("Failed to create form data".to_string());
+                        }
+                    };
+                    if let Err(_) = form_data.append_with_blob("file", &file) {
+                        gloo_console::error!("Failed to append file to FormData");
+                        return InventoryMsg::ServerError("Failed to append file".to_string());
+                    }
+                    let result: Result<_, String> = async {
+                        let response = Request::post("/api/inventory/csv")
+                            .body(form_data).map_err(|e| e.to_string())?
+                            .send()
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        if response.ok() {
+                            Ok(response)
+                        } else {
+                            Err(format!("Bad status code: {}", response.status()))
+                        }
+                    }
+                    .await;
+
+                    match result {
+                        Ok(_) => InventoryMsg::BulkChanged,
+                        Err(e) => {
+                            gloo_console::error!(format!("Failed to upload CSV: {e}"));
+                            InventoryMsg::ServerError(format!("{:?}", e))
+                        }
+                    }
+                });
             }
         }
 
@@ -443,6 +484,31 @@ impl InventoryPage {
                 self.item_rows.iter().map(item_row),
                 wide_button("wide_button", strings::NEW_ITEM, InventoryMsg::NewItem),
                 wide_anchor("wide_button_blue", strings::GENERATE_CSV, "/api/inventory/csv", "inventory.csv"),
+                tr![td![
+                    table_wide(),
+                    label![
+                        C![C.wide_button, "wide_button_blue"],
+                        "Upload CSV",
+                        input![
+                            attrs!{At::Type => "file", At::Accept => ".csv", At::Style => "display: none;"},
+                            ev(Ev::Change, |event: web_sys::Event| {
+                                let Some(target) = event.target() else {
+                                    return InventoryMsg::ServerError("No event target".to_string());
+                                };
+                                let Ok(input) = target.dyn_into::<web_sys::HtmlInputElement>() else {
+                                    return InventoryMsg::ServerError("Event target is not an input element".to_string());
+                                };
+                                let Some(files) = input.files() else {
+                                    return InventoryMsg::ServerError("No files available".to_string());
+                                };
+                                let Some(file) = files.get(0) else {
+                                    return InventoryMsg::ServerError("No file selected".to_string());
+                                };
+                                InventoryMsg::UploadCsv(file)
+                            })
+                        ]
+                    ]
+                ]],
             ],
         ]
         .map_msg(Msg::Inventory)

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -269,6 +269,7 @@ impl InventoryPage {
             }
             InventoryMsg::BulkChanged => {
                 rs.mark_as_dirty(Res::items_url(), orders);
+                rs.mark_as_dirty(Res::bundles_url(), orders);
             }
             InventoryMsg::ServerError(message) => {
                 orders.send_msg(Msg::Notification(NotificationMessage::ShowNotification {
@@ -309,7 +310,7 @@ impl InventoryPage {
                         return InventoryMsg::ServerError("Failed to append file".to_string());
                     }
                     let result: Result<_, String> = async {
-                        let response = Request::post("/api/inventory/csv")
+                        let response = Request::put("/api/inventory/csv/update")
                             .body(form_data).map_err(|e| e.to_string())?
                             .send()
                             .await

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -39,8 +39,6 @@ pub enum InventoryMsg {
 
     BundleInput(Field, InventoryBundleId, ParsedInputMsg),
     ItemInput(Field, InventoryItemId, ParsedInputMsg),
-
-    GenerateCsv,
 }
 
 pub struct InventoryPage {
@@ -292,41 +290,6 @@ impl InventoryPage {
                     Field::Image => row.map(|row| row.image.update(msg)),
                 };
             }
-            InventoryMsg::GenerateCsv => {
-                orders_local.perform_cmd(async move {
-                    let result: Result<_, String> = async {
-                        let response = Request::get("/api/inventory/csv")
-                            .send()
-                            .await
-                            .map_err(|e| e.to_string())?;
-                        if response.ok() {
-                            Ok(response)
-                        } else {
-                            Err(format!("Bad status code: {}", response.status()))
-                        }
-                    }
-                    .await;
-
-                    match result {
-                        Ok(response) => {
-                            match response.text().await {
-                                Ok(_text) => {
-                                    // TODO: download CSV file
-                                    InventoryMsg::ServerError("CSV download not implemented yet".into())
-                                }
-                                Err(e) => {
-                                    gloo_console::error!(format!("Failed to get text: {e}"));
-                                    InventoryMsg::ServerError(format!("{:?}", e))
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            gloo_console::error!(format!("Failed to download CSV: {e}"));
-                            InventoryMsg::ServerError(format!("{:?}", e))
-                        }
-                    }
-                });
-            }
         }
 
         Ok(())
@@ -450,6 +413,13 @@ impl InventoryPage {
             ]]
         };
 
+        let wide_anchor = |class: &str, label: &str, href: &str, download: &str| {
+            tr![td![
+                table_wide(),
+                a![C![C.wide_button, class], attrs!{At::Href => href, At::Download => download}, label],
+            ]]
+        };
+
         let header = || {
             tr![
                 th![],
@@ -472,7 +442,7 @@ impl InventoryPage {
                 header(),
                 self.item_rows.iter().map(item_row),
                 wide_button("wide_button", strings::NEW_ITEM, InventoryMsg::NewItem),
-                wide_button("wide_button_blue", strings::GENERATE_CSV, InventoryMsg::GenerateCsv),
+                wide_anchor("wide_button_blue", strings::GENERATE_CSV, "/api/inventory/csv", "inventory.csv"),
             ],
         ]
         .map_msg(Msg::Inventory)

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -348,6 +348,11 @@ impl InventoryPage {
         for (&id, bundle) in res.bundles.iter() {
             if let Some(row) = self.bundle_rows.get_mut(&id) {
                 row.original = bundle.clone();
+                row.name = ParsedInput::new_with_text(&bundle.name);
+                row.price = err(ParsedInput::new_with_value(bundle.price));
+                row.image = ParsedInput::new_with_text(
+                    bundle.image_url.as_deref().unwrap_or(""),
+                );
             } else {
                 self.bundle_rows.insert(
                     id,
@@ -368,6 +373,12 @@ impl InventoryPage {
         for (&id, item) in res.items.iter() {
             if let Some(row) = self.item_rows.get_mut(&id) {
                 row.original = item.clone();
+                row.name = ParsedInput::new_with_text(&item.name);
+                row.price = err(match item.price {
+                    Some(price) => ParsedInput::new_with_value(Currency::from(price)),
+                    None => ParsedInput::new(),
+                });
+                row.image = ParsedInput::new_with_text(item.image_url.as_deref().unwrap_or(""));
             } else {
                 self.item_rows.insert(
                     id,

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -1,7 +1,7 @@
 use crate::app::Msg;
 use crate::components::parsed_input::{ParsedInput, ParsedInputMsg};
 use crate::generated::css_classes::C;
-use crate::notification_manager::{Notification, NotificationMessage};
+use crate::notification_manager::{Notification, NotificationMessage, NotificationType};
 use crate::page::loading::Loading;
 use crate::strings;
 use crate::util::simple_ev;
@@ -273,6 +273,14 @@ impl InventoryPage {
             InventoryMsg::BulkChanged => {
                 rs.mark_as_dirty(Res::items_url(), orders);
                 rs.mark_as_dirty(Res::bundles_url(), orders);
+                orders.send_msg(Msg::Notification(NotificationMessage::ShowNotification {
+                    duration_ms: 5000,
+                    notification: Notification {
+                        title: strings::CSV_UPLOAD_SUCCESS.to_string(),
+                        body: Some(strings::CSV_UPLOAD_SUCCESS_BODY.to_string()),
+                        notification_type: NotificationType::Success,
+                    },
+                }));
             }
             InventoryMsg::ServerError(message) => {
                 orders.send_msg(Msg::Notification(NotificationMessage::ShowNotification {
@@ -280,6 +288,7 @@ impl InventoryPage {
                     notification: Notification {
                         title: strings::SERVER_ERROR.to_string(),
                         body: Some(message),
+                        notification_type: NotificationType::Error,
                     },
                 }));
             }

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -39,6 +39,8 @@ pub enum InventoryMsg {
 
     BundleInput(Field, InventoryBundleId, ParsedInputMsg),
     ItemInput(Field, InventoryItemId, ParsedInputMsg),
+
+    GenerateCsv,
 }
 
 pub struct InventoryPage {
@@ -290,6 +292,41 @@ impl InventoryPage {
                     Field::Image => row.map(|row| row.image.update(msg)),
                 };
             }
+            InventoryMsg::GenerateCsv => {
+                orders_local.perform_cmd(async move {
+                    let result: Result<_, String> = async {
+                        let response = Request::get("/api/inventory/csv")
+                            .send()
+                            .await
+                            .map_err(|e| e.to_string())?;
+                        if response.ok() {
+                            Ok(response)
+                        } else {
+                            Err(format!("Bad status code: {}", response.status()))
+                        }
+                    }
+                    .await;
+
+                    match result {
+                        Ok(response) => {
+                            match response.text().await {
+                                Ok(_text) => {
+                                    // TODO: download CSV file
+                                    InventoryMsg::ServerError("CSV download not implemented yet".into())
+                                }
+                                Err(e) => {
+                                    gloo_console::error!(format!("Failed to get text: {e}"));
+                                    InventoryMsg::ServerError(format!("{:?}", e))
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            gloo_console::error!(format!("Failed to download CSV: {e}"));
+                            InventoryMsg::ServerError(format!("{:?}", e))
+                        }
+                    }
+                });
+            }
         }
 
         Ok(())
@@ -406,10 +443,10 @@ impl InventoryPage {
 
         let table_wide = || attrs! { At::ColSpan => 6 };
 
-        let wide_button = |label: &str, msg: InventoryMsg| {
+        let wide_button = |class: &str, label: &str, msg: InventoryMsg| {
             tr![td![
                 table_wide(),
-                button![C![C.wide_button], simple_ev(Ev::Click, msg), label,],
+                button![C![C.wide_button, class], simple_ev(Ev::Click, msg), label,],
             ]]
         };
 
@@ -430,11 +467,12 @@ impl InventoryPage {
                 td![table_wide(), h1![strings::INVENTORY_BUNDLES]],
                 header(),
                 self.bundle_rows.iter().map(bundle_row),
-                wide_button(strings::NEW_BUNDLE, InventoryMsg::NewBundle),
+                wide_button("wide_button", strings::NEW_BUNDLE, InventoryMsg::NewBundle),
                 td![table_wide(), h1![strings::INVENTORY_ITEMS]],
                 header(),
                 self.item_rows.iter().map(item_row),
-                wide_button(strings::NEW_ITEM, InventoryMsg::NewItem),
+                wide_button("wide_button", strings::NEW_ITEM, InventoryMsg::NewItem),
+                wide_button("wide_button_blue", strings::GENERATE_CSV, InventoryMsg::GenerateCsv),
             ],
         ]
         .map_msg(Msg::Inventory)

--- a/frontend/src/page/inventory.rs
+++ b/frontend/src/page/inventory.rs
@@ -41,11 +41,13 @@ pub enum InventoryMsg {
     BundleInput(Field, InventoryBundleId, ParsedInputMsg),
     ItemInput(Field, InventoryItemId, ParsedInputMsg),
     UploadCsv(web_sys::File),
+    SetShowSidePanel(bool),
 }
 
 pub struct InventoryPage {
     bundle_rows: BTreeMap<InventoryBundleId, Row<InventoryBundle>>,
     item_rows: BTreeMap<InventoryItemId, Row<InventoryItem>>,
+    show_side_panel: bool,
 }
 
 #[derive(Resources)]
@@ -81,6 +83,7 @@ impl InventoryPage {
         let mut p = InventoryPage {
             item_rows: Default::default(),
             bundle_rows: Default::default(),
+            show_side_panel: false,
         };
         if let Ok(state) = Res::acquire(rs, orders) {
             p.rebuild_data(&state);
@@ -332,6 +335,9 @@ impl InventoryPage {
                     }
                 });
             }
+            InventoryMsg::SetShowSidePanel(show_side_panel) => {
+                self.show_side_panel = show_side_panel;
+            }
         }
 
         Ok(())
@@ -466,13 +472,6 @@ impl InventoryPage {
             ]]
         };
 
-        let wide_anchor = |class: &str, label: &str, href: &str, download: &str| {
-            tr![td![
-                table_wide(),
-                a![C![C.wide_button, class], attrs!{At::Href => href, At::Download => download}, label],
-            ]]
-        };
-
         let header = || {
             tr![
                 th![],
@@ -486,21 +485,29 @@ impl InventoryPage {
 
         div![
             C![C.inventory_page],
-            table![
-                td![table_wide(), h1![strings::INVENTORY_BUNDLES]],
-                header(),
-                self.bundle_rows.iter().map(bundle_row),
-                wide_button("wide_button", strings::NEW_BUNDLE, InventoryMsg::NewBundle),
-                td![table_wide(), h1![strings::INVENTORY_ITEMS]],
-                header(),
-                self.item_rows.iter().map(item_row),
-                wide_button("wide_button", strings::NEW_ITEM, InventoryMsg::NewItem),
-                wide_anchor("wide_button_blue", strings::GENERATE_CSV, "/api/inventory/csv", "inventory.csv"),
-                tr![td![
-                    table_wide(),
+            // Side panel for CSV operations
+            div![
+                C![C.left_panel],
+                if self.show_side_panel {
+                    C![C.left_panel_showing]
+                } else {
+                    C![]
+                },
+                div![
+                    C![C.left_panel_entry],
+                    h2![C![C.left_panel_entry_header], strings::CSV_FEATURE_HEADER],
+                    p![strings::CSV_FEATURE_DESCRIPTION],
+                ],
+                div![
+                    C![C.left_panel_entry],
+                    a![
+                        C![C.wide_button, C.wide_button_blue],
+                        attrs!{At::Href => "/api/inventory/csv", At::Download => "inventory.csv"},
+                        strings::GENERATE_CSV,
+                    ],
                     label![
-                        C![C.wide_button, "wide_button_blue"],
-                        "Upload CSV",
+                        C![C.wide_button, C.wide_button_blue, C.space_above],
+                        strings::UPLOAD_CSV,
                         input![
                             attrs!{At::Type => "file", At::Accept => ".csv", At::Style => "display: none;"},
                             ev(Ev::Change, |event: web_sys::Event| {
@@ -520,7 +527,33 @@ impl InventoryPage {
                             })
                         ]
                     ]
-                ]],
+                ],
+            ],
+            // Toggle button for side panel
+            button![
+                C![C.left_panel_button],
+                simple_ev(
+                    Ev::Click,
+                    InventoryMsg::SetShowSidePanel(!self.show_side_panel),
+                ),
+                "⚙"
+            ],
+            // Spacer to prevent content from being hidden behind the side panel
+            div![if self.show_side_panel {
+                C![C.left_panel_sub_spacer]
+            } else {
+                C![C.left_panel_sub_spacer, C.left_panel_sub_spacer_hidden]
+            },],
+            // Main inventory table
+            table![
+                td![table_wide(), h1![strings::INVENTORY_BUNDLES]],
+                header(),
+                self.bundle_rows.iter().map(bundle_row),
+                wide_button("wide_button", strings::NEW_BUNDLE, InventoryMsg::NewBundle),
+                td![table_wide(), h1![strings::INVENTORY_ITEMS]],
+                header(),
+                self.item_rows.iter().map(item_row),
+                wide_button("wide_button", strings::NEW_ITEM, InventoryMsg::NewItem),
             ],
         ]
         .map_msg(Msg::Inventory)

--- a/frontend/src/page/store.rs
+++ b/frontend/src/page/store.rs
@@ -3,7 +3,7 @@ use crate::components::checkout::{Checkout, CheckoutMsg};
 use crate::components::izettle_pay::{IZettlePay, IZettlePayErr, IZettlePayMsg};
 use crate::fuzzy_search::{FuzzyScore, FuzzySearch};
 use crate::generated::css_classes::C;
-use crate::notification_manager::{Notification, NotificationMessage};
+use crate::notification_manager::{Notification, NotificationMessage, NotificationType};
 use crate::page::loading::Loading;
 use crate::strings;
 use crate::util::{compare_fuzzy, simple_ev};
@@ -281,6 +281,7 @@ impl StorePage {
                     notification: Notification {
                         title: message_title,
                         body: message_body,
+                        notification_type: NotificationType::Error,
                     },
                 }));
             }
@@ -314,6 +315,7 @@ impl StorePage {
                                     "Total: {}:-",
                                     self.checkout.transaction_amount(),
                                 )),
+                                notification_type: NotificationType::Success,
                             },
                         }));
                         self.checkout = Checkout::new(

--- a/frontend/src/strings.rs
+++ b/frontend/src/strings.rs
@@ -42,3 +42,6 @@ pub const CSV_FEATURE_HEADER: &str = "CSV Hantering";
 pub const CSV_FEATURE_DESCRIPTION: &str = "Importera och exportera inventariedata via CSV-filer för enklare bulkhantering.";
 pub const GENERATE_CSV: &str = "Generera CSV för bulkhantering";
 pub const UPLOAD_CSV: &str = "Ladda upp och hantera CSV-fil";
+pub const CSV_UPLOAD_SUCCESS: &str = "CSV uppladdad";
+pub const CSV_UPLOAD_SUCCESS_BODY: &str = "Inventariedata har uppdaterats från CSV-filen.";
+

--- a/frontend/src/strings.rs
+++ b/frontend/src/strings.rs
@@ -38,4 +38,7 @@ pub const INVENTORY_BUNDLES: &str = "Paket";
 pub const NEW_ITEM: &str = "Ny vara";
 pub const NEW_BUNDLE: &str = "Nytt paket";
 
+pub const CSV_FEATURE_HEADER: &str = "CSV Hantering";
+pub const CSV_FEATURE_DESCRIPTION: &str = "Importera och exportera inventariedata via CSV-filer för enklare bulkhantering.";
 pub const GENERATE_CSV: &str = "Generera CSV för bulkhantering";
+pub const UPLOAD_CSV: &str = "Ladda upp och hantera CSV-fil";

--- a/frontend/src/strings.rs
+++ b/frontend/src/strings.rs
@@ -37,3 +37,5 @@ pub const INVENTORY_ITEMS: &str = "Varor";
 pub const INVENTORY_BUNDLES: &str = "Paket";
 pub const NEW_ITEM: &str = "Ny vara";
 pub const NEW_BUNDLE: &str = "Nytt paket";
+
+pub const GENERATE_CSV: &str = "Generera CSV för bulkinmatning";

--- a/frontend/src/strings.rs
+++ b/frontend/src/strings.rs
@@ -38,4 +38,4 @@ pub const INVENTORY_BUNDLES: &str = "Paket";
 pub const NEW_ITEM: &str = "Ny vara";
 pub const NEW_BUNDLE: &str = "Nytt paket";
 
-pub const GENERATE_CSV: &str = "Generera CSV för bulkinmatning";
+pub const GENERATE_CSV: &str = "Generera CSV för bulkhantering";

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1121,6 +1121,18 @@ video {
 	cursor: default;
 }
 
+.wide_button_blue {
+	background-color: #007bff;
+}
+
+.wide_button_blue:hover {
+	background-color: #0056b3;
+}
+
+.wide_button_blue:disabled {
+	background-color: #6c757d;
+}
+
 .button_danger {
 	background-color: #7b3434;
 }

--- a/frontend/static/styles/common.css
+++ b/frontend/static/styles/common.css
@@ -1110,6 +1110,8 @@ video {
 	font-size: 100%;
 	line-height: 1.15;
 	width: 100%;
+	display: block;
+	text-align: center;
 }
 
 .wide_button:hover {
@@ -1126,7 +1128,7 @@ video {
 }
 
 .wide_button_blue:hover {
-	background-color: #0056b3;
+	background-color: #3399ff;
 }
 
 .wide_button_blue:disabled {

--- a/frontend/static/styles/notifications.css
+++ b/frontend/static/styles/notifications.css
@@ -14,6 +14,14 @@
 	animation: notification_enter 1s 1;
 }
 
+.notification_error {
+	background-color: #7b3434;
+}
+
+.notification_success {
+	background-color: #1f9d55;
+}
+
 .notification_body {
 	overflow-wrap: break-word;
 }


### PR DESCRIPTION
This PR adds the ability to use CSVs for various kinds of bulk operations (adjusting prices, stock, adding items etc). Currently works by downloading a CSV of the current inventory, modifying it, and uploading it again. Various things could be built ontop of this, such as adding purchase price and automatically figuring out what the new price should be in the shop etc. but that could be added at a later date.

To use the new feature, press the cog icon in the upper left on the inventory page. Also adds various .env attributes that should be used to configure the feature on real deployments.